### PR TITLE
Reduce Extrude MinTemp

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -250,7 +250,7 @@
 //if PREVENT_DANGEROUS_EXTRUDE is on, you can still disable (uncomment) very long bits of extrusion separately.
 #define PREVENT_LENGTHY_EXTRUDE
 
-#define EXTRUDE_MINTEMP 170
+#define EXTRUDE_MINTEMP 50 //legacy set to 170 to prevent hotend damage. This is not a concern for TAM Series 1
 #define EXTRUDE_MAXLENGTH (X_MAX_LENGTH+Y_MAX_LENGTH) //prevent extrusion of very large distances.
 
 //===========================================================================


### PR DESCRIPTION
Extrude mintemp reduced to 50C. The legacy was 170 to keep from destroying the teflon and brass print heads, but this is not a concern with the all steel versions.